### PR TITLE
link to webrecorder

### DIFF
--- a/templates/summary.html
+++ b/templates/summary.html
@@ -312,9 +312,9 @@ function chart(id, data, fieldname, searchPrefix) {
                 if (id == "hashtags") {
                     url = "https://twitter.com/search?q=%23" + d;
                 } else if (id == "domains") {
-                    url = "https://webrecorder.io/record/" + "http://" + d;
+                    url = "https://new.webrecorder.io/record/" + "http://" + d;
                 } else if (id == "urls") {
-                    url = "https://webrecorder.io/record/" + d;
+                    url = "https://new.webrecorder.io/record/" + d;
                 } else {
                     url = "https://twitter.com/intent/user?screen_name=" + d;
                     specs = "location=no,height=570,width=520,scrollbars=no,status=yes";

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -312,9 +312,9 @@ function chart(id, data, fieldname, searchPrefix) {
                 if (id == "hashtags") {
                     url = "https://twitter.com/search?q=%23" + d;
                 } else if (id == "domains") {
-                    url = "https://new.webrecorder.io/record/" + "http://" + d;
+                    url = "https://webrecorder.io/live/" + "http://" + d;
                 } else if (id == "urls") {
-                    url = "https://new.webrecorder.io/record/" + d;
+                    url = "https://webrecorder.io/live/" + d;
                 } else {
                     url = "https://twitter.com/intent/user?screen_name=" + d;
                     specs = "location=no,height=570,width=520,scrollbars=no,status=yes";

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -312,7 +312,7 @@ function chart(id, data, fieldname, searchPrefix) {
                 if (id == "hashtags") {
                     url = "https://twitter.com/search?q=%23" + d;
                 } else if (id == "domains") {
-                    url = "https://webrecorder.io/live/" + "http://" + d;
+                    url = "http://" + d;
                 } else if (id == "urls") {
                     url = "https://webrecorder.io/live/" + d;
                 } else {

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -312,9 +312,9 @@ function chart(id, data, fieldname, searchPrefix) {
                 if (id == "hashtags") {
                     url = "https://twitter.com/search?q=%23" + d;
                 } else if (id == "domains") {
-                    url = "http://" + d;
+                    url = "https://webrecorder.io/record/" + "http://" + d;
                 } else if (id == "urls") {
-                    url = d;
+                    url = "https://webrecorder.io/record/" + d;
                 } else {
                     url = "https://twitter.com/intent/user?screen_name=" + d;
                     specs = "location=no,height=570,width=520,scrollbars=no,status=yes";


### PR DESCRIPTION
Clicking on URLs and domains in the reports takes you over to Webrecorder where
you can view that URL and capture it into an anonymous collection.

This isn't particularly useful since there is no continuity between the user on
dnflow and webrecorder. But it should at least help frame some of the discussion
about a tighter coordination between docnow and webrecorder in order to allow
researchers and archivists to identify material in need of archiving.

Fixes #11
