### PR TITLE
memory usage

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -16,7 +16,7 @@ DATABASE = 'db.sqlite3'
 SECRET_KEY = 'a super secret key'
 STATIC_URL_PATH = '/static'
 DATA_DIR = 'data'
-MAX_TIMEOUT = 30 * 60  # thirty minutes should be enough
+MAX_TIMEOUT = 2 * 60 * 60  # two hours should be long enough
 
 # FIXME: host hard-coded, and decode_responses shouldn't always be True
 redis_conn = redis.StrictRedis(host='localhost', charset='utf-8',


### PR DESCRIPTION
It appeared that the biggest user of memory was in FetchTweets which was
storing an in memory list of all retrieved tweets, and then writing them out
once the full list was assembled. So when I asked the app to collect 50k tweets
it was storing the parsed json for each tweet in memory. I observed this cause
the worker process to use all memory at which point redis died.

I solved the problem by writing the tweets to disk as they become available.
After reading the luigi.LocalTarget code it appears that it is smart enough to
write to a temporary file, and atomically move it into place once close is
called.

I also removed the storage of the entire tweet as a string in redis for now. We
aren't using it, and it seemed to cut down the memory footprint of redis in
half. Perhaps we'll need to add this back in, but I think I would rather prefer
to extract the things we need for the app rather than storing the whole thing in
memory.

I tested collecting 10k tweets with no problems.

Fixes #14
