### PR TITLE
API Routes

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -83,7 +83,7 @@ var SearchBox = React.createClass({
   handleSearchSubmit: function(search) {
     $.ajax({
       // url: this.props.url,
-      url: '/new',
+      url: '/searches/',
       dataType: 'json',
       type: 'POST',
       data: search,

--- a/summarize.py
+++ b/summarize.py
@@ -422,13 +422,6 @@ class MatchMedia(EventfulTask):
             logging.debug(' - = - = - = GRAPH HERE - = - = - = -')
             logging.debug(d)
             json.dump(d, fp_graph, indent=2)
-        # with self.output().open('w') as fp:
-        #    writer = csv.writer(fp, delimiter=',',
-        #                        quoting=csv.QUOTE_MINIMAL)
-        #    writer.writerow(['file1', 'file2', 'ahash', 'dhash',
-        #                     'phash', 'sumhash'])
-        #    for match in matches:
-        #        writer.writerow(match)
 
 
 class CountFollowers(EventfulTask):
@@ -620,7 +613,6 @@ class RunFlow(EventfulTask):
     jobid = luigi.IntParameter()
     term = luigi.Parameter()
     count = luigi.IntParameter(default=1000)
-    # lang = luigi.Parameter(default='en')
 
     def requires(self):
         EventfulTask.update_job(jobid=self.jobid, date_path=self.date_path)
@@ -628,7 +620,6 @@ class RunFlow(EventfulTask):
                             count=self.count)
         yield CountHashtags(date_path=self.date_path, term=self.term,
                             count=self.count)
-        # yield SummaryHTML(date_path=self.date_path, term=self.term)
         yield SummaryJSON(date_path=self.date_path, term=self.term,
                           count=self.count)
         yield EdgelistHashtags(date_path=self.date_path, term=self.term,

--- a/summarize.py
+++ b/summarize.py
@@ -43,10 +43,6 @@ def time_hash(digits=6):
     return '%s-%s' % (dt, hash.hexdigest()[:digits])
 
 
-def localstrftime():
-    return time.strftime('%Y-%m-%dT%H%M', time.localtime())
-
-
 def url_filename(url, include_extension=True):
     """Given a full URL, return just the filename after the last slash."""
     parsed_url = urlparse(url)

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -92,12 +92,12 @@ var y_axis = d3.svg.axis().scale(y).orient("left")
     .tickFormat(d3.format("d"));
 
 
-d3.json("/api/" + date_path + "/hashtags/", function(e, data) {
+d3.json("/api/searches/" + date_path + "/hashtags/", function(e, data) {
     if (e) return console.warn(e);
     chart("hashtags", data, "hashtag", "#");
 });
 
-d3.json("/api/" + date_path + "/mentions/", function(e, data) {
+d3.json("/api/searches/" + date_path + "/mentions/", function(e, data) {
     if (e) return console.warn(e);
     chart("mentions", data, "screen_name", "@");
 });

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -92,12 +92,12 @@ var y_axis = d3.svg.axis().scale(y).orient("left")
     .tickFormat(d3.format("d"));
 
 
-d3.json("/q/" + date_path + "/count-hashtags/", function(e, data) {
+d3.json("/api/" + date_path + "/hashtags/", function(e, data) {
     if (e) return console.warn(e);
     chart("hashtags", data, "hashtag", "#");
 });
 
-d3.json("/q/" + date_path + "/count-mentions/", function(e, data) {
+d3.json("/api/" + date_path + "/mentions/", function(e, data) {
     if (e) return console.warn(e);
     chart("mentions", data, "screen_name", "@");
 });

--- a/ui.py
+++ b/ui.py
@@ -1,13 +1,12 @@
+import redis
 import logging
 import sqlite3
 
-import redis
 from rq import Queue
-
-from flask import Flask, render_template, url_for, send_from_directory
-from flask import g, jsonify, request, redirect
-
 from queue_tasks import run_flow
+from flask import g, jsonify, request, redirect
+from flask import Flask, render_template, url_for, send_from_directory
+
 
 
 # FIXME: these should be in a separate config file
@@ -60,13 +59,16 @@ def teardown_request(exception):
         db.close()
 
 
+# Web views
+
+
 @app.route('/', methods=['GET'])
 def index():
     searches = query('SELECT * FROM searches ORDER BY id DESC')
     return render_template('index.html', searches=searches)
 
 
-@app.route('/new', methods=['POST'])
+@app.route('/searches/', methods=['POST'])
 def add_search():
     text = request.form.get('text', None)
     try:
@@ -79,7 +81,7 @@ def add_search():
               [request.form['text'], ''])
         g.db.commit()
         r = query(sql='SELECT last_insert_rowid() AS job_id FROM searches',
-                  one=True)
+                 one=True)
         job_id = r['job_id']
         job = q.enqueue_call(run_flow, args=(text, job_id, count),
                              timeout=app.config['MAX_TIMEOUT'])
@@ -92,6 +94,7 @@ def job():
     job_id = request.form.get('job_id', None)
     date_path = request.form.get('date_path', None)
     status = request.form.get('status', None)
+
     # A job is starting, we want the date_path
     if job_id and date_path:
         query('UPDATE searches SET date_path = ? WHERE id = ?',
@@ -108,12 +111,6 @@ def job():
     return redirect(url_for('index'))
 
 
-@app.route('/api/searches/', methods=['GET'])
-def api_searches():
-    searches = query('SELECT * FROM searches ORDER BY id DESC', json=True)
-    return jsonify(searches)
-
-
 @app.route('/summary/<date_path>/', methods=['GET'])
 def summary(date_path):
     return render_template('summary.html')
@@ -123,6 +120,27 @@ def summary(date_path):
 def summary_static_proxy(date_path, file_name):
     fname = '%s/%s' % (date_path, file_name)
     return send_from_directory(app.config['DATA_DIR'], fname)
+
+
+# api routes for getting data below
+
+
+@app.route('/api/searches/', methods=['GET'])
+def api_searches():
+    searches = query('SELECT * FROM searches ORDER BY id DESC', json=True)
+    return jsonify(searches)
+
+
+@app.route('/api/searches/<date_path>/hashtags/', methods=['GET'])
+def hashtags(date_path):
+    d = _count_entities(date_path, 'hashtags', 'hashtag')
+    return jsonify(d)
+
+
+@app.route('/api/searches/<date_path>/mentions/', methods=['GET'])
+def mentions(date_path):
+    d = _count_entities(date_path, 'mentions', 'screen_name')
+    return jsonify(d)
 
 
 def _count_entities(date_path, entity, attrname):
@@ -136,16 +154,6 @@ def _count_entities(date_path, entity, attrname):
     return [{attrname: e, 'count': c} for e, c in counts]
 
 
-@app.route('/q/<date_path>/count-hashtags/', methods=['GET'])
-def q_count_hashtags(date_path):
-    d = _count_entities(date_path, 'hashtags', 'hashtag')
-    return jsonify(d)
-
-
-@app.route('/q/<date_path>/count-mentions/', methods=['GET'])
-def q_count_mentions(date_path):
-    d = _count_entities(date_path, 'mentions', 'screen_name')
-    return jsonify(d)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I updated a few URL paths to put data serving routes under `/api/`. I apologize if this causes any problems with other work that is underway. There isn't much code in `ui` but I was already starting to feel a little lost, and grouping things this way helps me at least.

I did find myself wanting to update the way job status PUTs worked, to be based of off the job_id, but that ended up impacting the `summarize` module more than I wanted as part of this.

I did find myself wanting to call things _datasets_ instead of _searches_ but I backed away from making that change as well. This is why we do prototypes eh? :-)
