### PR TITLE
Compare searches

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ imagehash
 Jinja2
 luigi
 networkx
+pandas
 redis
 rq
 sqlalchemy

--- a/summarize.py
+++ b/summarize.py
@@ -500,6 +500,7 @@ class SummaryJSON(EventfulTask):
                      for m in tweet['entities'].get('media', [])
                      if m['type'] == 'photo'])
         summary = {
+                'id': self.search['job_id'],
                 'path': self.search['date_path'],
                 'date': time.strftime('%Y-%m-%d %H:%M:%S',
                                       time.localtime()),
@@ -514,7 +515,7 @@ class PopulateRedis(EventfulTask):
     search = luigi.DictParameter()
 
     def _get_target(self):
-        return redis_store.RedisTarget(host=config['REDIS_HOST'], 
+        return redis_store.RedisTarget(host=config['REDIS_HOST'],
                                        port=config['REDIS_PORT'],
                                        db=config['REDIS_DB'],
                                        update_id=self.search['date_path'])
@@ -614,7 +615,8 @@ class RunFlow(EventfulTask):
             "lang": "en"
         }
         self.search = search
-        EventfulTask.update_job(job_id=search['job_id'], date_path=search['date_path'])
+        EventfulTask.update_job(job_id=search['job_id'],
+                                date_path=search['date_path'])
         yield CountHashtags(search=search)
         yield SummaryJSON(search=search)
         yield EdgelistHashtags(search=search)

--- a/templates/base.html
+++ b/templates/base.html
@@ -36,9 +36,6 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.23/browser.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.0/jquery.min.js"></script>
         {% endblock javascript %}
-
-        {% block javascript_extra %}
-        {% endblock javascript_extra %}
     </head>
 
     <body>
@@ -64,5 +61,8 @@
 {% endblock content %}
             </div>
         </div>
+
+        {% block javascript_extra %}
+        {% endblock javascript_extra %}
     </body>
 </html>

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -276,6 +276,31 @@ function chart(id, data, fieldname, searchPrefix) {
         .attr("y", function(d) { return y(d.count); })
         .attr("height", function(d) { return height - y(d.count); });
 };
+
+d3.json("/api/searches", function(e, data) {
+    if (e) return console.warn(e);
+    var comparisons = d3.select("#compare").append("ul");
+
+    // remove the present search from the list for comparison
+    data = data.filter(function(d) {
+        if (d.date_path === date_path) {
+            return false;
+        } else {
+            return true;
+        }
+    });
+
+    comparisons.selectAll(".search")
+        .data(data)
+      .enter().append("li")
+        .append("a")
+          .attr("href", function(d) {
+              return "/summary/" + date_path + "/compare?id=" + d.id;
+              })
+          .text(function(d) { return d.text; });
+});
+
+
 </script>
 {% endblock javascript_extra %}
 
@@ -329,6 +354,11 @@ function chart(id, data, fieldname, searchPrefix) {
 <div class="row">
     <div id="media-matches" class="item">
         <h3>Matching images</h3>
+    </div>
+</div>
+<div class="row">
+    <div id="compare" class="item">
+        <h3>Compare with other searches</h3>
     </div>
 </div>
 <div class="row">

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -290,23 +290,23 @@ d3.json("/api/searches", function(e, data) {
         }
     });
 
+    var search_id = d3.select("#search_id").text();
     comparisons.selectAll(".search")
         .data(data)
       .enter().append("li")
         .append("a")
           .attr("href", function(d) {
-              return "/summary/" + date_path + "/compare?id=" + d.id;
+              return "/summary/" + search_id + "/compare?id=" + d.id;
               })
           .text(function(d) { return d.text; });
 });
-
-
 </script>
 {% endblock javascript_extra %}
 
 {% block content %}
 <div class="row">
     <h2 class="item">
+        #<span id="search_id">{{ search.id }}</span>:
         <span id="num_tweets"></span>
         tweets collected on
         <span id="date"></span>

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -296,7 +296,7 @@ d3.json("/api/searches", function(e, data) {
       .enter().append("li")
         .append("a")
           .attr("href", function(d) {
-              return "/summary/" + search_id + "/compare?id=" + d.id;
+              return "/summary/" + search_id + "/compare?ids=" + d.id;
               })
           .text(function(d) { return d.text; });
 });

--- a/templates/summary_compare.html
+++ b/templates/summary_compare.html
@@ -1,11 +1,33 @@
 {% extends "base.html" %}
 
 {% block style_css_extra %}
+body {
+  font: 12px sans-serif;
+}
+
+.axis path,
+.axis line {
+  fill: none;
+  stroke: #000;
+  shape-rendering: crispEdges;
+}
+
+.bar {
+  fill: steelblue;
+}
+
+.x.axis path {
+  display: none;
+}
 {% endblock style_css_extra %}
 
 {% block javascript_extra %}
 <script type="text/javascript">
+/* extract some vals from html; FIXME: awkward */
 var date_path = d3.select("#date_path").text();
+var search_id = d3.select("#search_id").text();
+var compare_ids = d3.select("#compare_ids").text();
+
 d3.json("/summary/" + date_path + "/summary.json", function(e, summary) {
     if (e) return console.warn(e);
     d3.select('#title').text("Compare: " + summary.term);
@@ -14,7 +36,130 @@ d3.json("/summary/" + date_path + "/summary.json", function(e, summary) {
     d3.select('#num_tweets').text(num_tweets.toLocaleString());
 });
 
+var hashtags_multi_url = "/api/hashtags/" + search_id + "?ids=" + compare_ids;
+var resp;
 
+var margin = {top: 20, right: 20, bottom: 100, left: 40},
+    width = 1100 - margin.left - margin.right,
+    height = 700 - margin.top - margin.bottom;
+
+var x_hashtag = d3.scale.ordinal()
+    .rangeRoundBands([0, width], .1);
+
+var x_search = d3.scale.ordinal();
+
+var y = d3.scale.linear()
+    .range([height, 0]);
+
+var color = d3.scale.category20c();
+
+var xAxis = d3.svg.axis()
+    .scale(x_hashtag)
+    .orient("bottom");
+
+var yAxis = d3.svg.axis()
+    .scale(y)
+    .orient("left")
+    .tickFormat(d3.format(".2s"));
+
+var svg = d3.select("#hashtags").append("svg")
+    .attr("width", width + margin.left + margin.right)
+    .attr("height", height + margin.top + margin.bottom)
+  .append("g")
+    .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+
+var resp;
+var colnames;
+var hashtags;
+var base_search_name;
+d3.json(hashtags_multi_url, function(e, data) {
+    if (e) return console.warn(e);
+    /* just for debugging */
+    resp = data;
+
+    var summary = data.summary;
+    /* limit the volume of hashtags to render - TODO: this is arbitrary */
+    hashtags = data.hashtags.slice(0, 25);
+
+    /* manipulate data into the right shape as needed */
+    colnames = summary.map(function(d) {
+      return {colname: d.colname, text: d.text};
+    });
+    hashtags.forEach(function(d) {
+      d.counts = colnames.map(function(col) {
+        return {name: col.colname, value: +d[col.colname]}; });
+    });
+
+    base_search_name = "count_" + search_id;
+    /* set domains for each scale */
+    x_hashtag.domain(hashtags.map(function(d) { return d.hashtag; }));
+    y.domain([0, d3.max(hashtags.map(function(d) { return d[base_search_name]; }))]);
+    x_search.domain(colnames.map(function(d) { return d.colname; }))
+      .rangeRoundBands([0, x_hashtag.rangeBand()]);
+    color.domain(colnames.map(function(d) { return d.colname; }));
+
+    svg.append("g")
+      .attr("class", "x axis")
+      .attr("transform", "translate(0," + height + ")")
+      .call(xAxis)
+      .selectAll("text")
+        .style("text-anchor", "end")
+        .attr("dx", "-0.8em")
+        .attr("dy", "0.2em")
+        .style("cursor", "pointer")
+        .on("click", function(d) {
+          var url = "https://twitter.com/search?q=%23" + d;
+          window.open(url, "_blank");
+        })
+        .attr("transform", "rotate(-60)");
+
+    svg.append("g")
+        .attr("class", "y axis")
+        .call(yAxis)
+      .append("text")
+        .attr("transform", "rotate(-90)")
+        .attr("y", 6)
+        .attr("dy", ".31em")
+        .style("text-anchor", "end")
+        .text("# tweets");
+
+    var hashtag = svg.selectAll(".hashtag")
+        .data(hashtags)
+      .enter().append("g")
+        .attr("class", "hashtag")
+        .attr("transform", function(d) {
+          return "translate(" + x_hashtag(d.hashtag) + ",0)";
+        });
+
+    hashtag.selectAll("rect")
+        .data(function(d) { return d.counts; })
+      .enter().append("rect")
+        .attr("width", x_search.rangeBand())
+        .attr("x", function(d) { return x_search(d.name); })
+        .attr("y", function(d) { return y(d.value); })
+        .attr("height", function(d) { return height - y(d.value); })
+        .style("fill", function(d) { return color(d.name); });
+
+    var legend = svg.selectAll(".legend")
+        .data(colnames.slice().reverse())
+      .enter().append("g")
+        .attr("class", "legend")
+        .attr("transform", function(d, i) { return "translate(0," + i * 20 + ")"; });
+
+    legend.append("rect")
+        .attr("x", width - 18)
+        .attr("width", 18)
+        .attr("height", 18)
+        .style("fill", function(d) { return color(d.colname); });
+
+    legend.append("text")
+        .attr("x", width - 24)
+        .attr("y", 9)
+        .attr("dy", ".35em")
+        .style("text-anchor", "end")
+        .text(function(d) { return d.text; });
+
+});
 </script>
 {% endblock javascript_extra %}
 
@@ -26,6 +171,12 @@ d3.json("/summary/" + date_path + "/summary.json", function(e, summary) {
         tweets collected on
         <span id="date"></span>
         <span id="date_path" style="display:none;">{{ search.date_path }}</span>
+        <span id="compare_ids" style="display:none;">{{ compare_ids }}</span>
     </h2>
+</div>
+<div class="row">
+    <div id="hashtags" class="item">
+        <h3>Hashtags</h3>
+    </div>
 </div>
 {% endblock content %}

--- a/templates/summary_compare.html
+++ b/templates/summary_compare.html
@@ -2,7 +2,7 @@
 
 {% block style_css_extra %}
 body {
-  font: 12px sans-serif;
+  font: 13px sans-serif;
 }
 
 .axis path,
@@ -19,6 +19,17 @@ body {
 .x.axis path {
   display: none;
 }
+
+.hashtag {
+  stroke-width: 1;
+  stroke: #eee;
+}
+
+.legend {
+  stroke-width: 1;
+  stroke: #888;
+}
+
 {% endblock style_css_extra %}
 
 {% block javascript_extra %}
@@ -69,20 +80,32 @@ var svg = d3.select("#hashtags").append("svg")
     .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
 
 var resp;
-var colnames;
-var hashtags;
-var base_search_name;
 d3.json(hashtags_multi_url, function(e, data) {
     if (e) return console.warn(e);
     /* just for debugging */
     resp = data;
 
+    var base_search_name = "count_" + search_id;
     var summary = data.summary;
+
+    var other_searches = summary.filter(function(d) {
+      return d.id != search_id;
+    });
+    var search_list = d3.select("#search_list").append("div")
+      .attr("class", "row");
+    search_list.selectAll(".search")
+        .data(other_searches)
+      .enter().append("h3")
+        .attr("class", "item")
+        .append("a")
+        .attr("href", function(d) { return "/summary/" + d.date_path + "/"; })
+        .text(function(d) { return d.text; });
+
     /* limit the volume of hashtags to render - TODO: this is arbitrary */
-    hashtags = data.hashtags.slice(0, 25);
+    var hashtags = data.hashtags.slice(0, 25);
 
     /* manipulate data into the right shape as needed */
-    colnames = summary.map(function(d) {
+    var colnames = summary.map(function(d) {
       return {colname: d.colname, text: d.text};
     });
     hashtags.forEach(function(d) {
@@ -90,12 +113,11 @@ d3.json(hashtags_multi_url, function(e, data) {
         return {name: col.colname, value: +d[col.colname]}; });
     });
 
-    base_search_name = "count_" + search_id;
     /* set domains for each scale */
     x_hashtag.domain(hashtags.map(function(d) { return d.hashtag; }));
-    y.domain([0, d3.max(hashtags.map(function(d) { return d[base_search_name]; }))]);
     x_search.domain(colnames.map(function(d) { return d.colname; }))
       .rangeRoundBands([0, x_hashtag.rangeBand()]);
+    y.domain([0, d3.max(hashtags.map(function(d) { return d[base_search_name]; }))]);
     color.domain(colnames.map(function(d) { return d.colname; }));
 
     svg.append("g")
@@ -166,13 +188,16 @@ d3.json(hashtags_multi_url, function(e, data) {
 {% block content %}
 <div class="row">
     <h2 class="item">
-        Compare #<span id="search_id">{{ search.id }}</span>:
-        <span id="num_tweets"></span>
-        tweets collected on
-        <span id="date"></span>
         <span id="date_path" style="display:none;">{{ search.date_path }}</span>
         <span id="compare_ids" style="display:none;">{{ compare_ids }}</span>
+        <span id="search_id" style="display:none;">{{ search.id }}</span>
+        Comparing <span id="num_tweets"></span>
+        tweets collected on
+        <span id="date"></span>
+        with:
     </h2>
+</div>
+<div class="row" id="search_list">
 </div>
 <div class="row">
     <div id="hashtags" class="item">

--- a/templates/summary_compare.html
+++ b/templates/summary_compare.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+
+{% block style_css_extra %}
+{% endblock style_css_extra %}
+
+{% block javascript_extra %}
+<script type="text/javascript">
+var date_path = d3.select("#date_path").text();
+d3.json("/summary/" + date_path + "/summary.json", function(e, summary) {
+    if (e) return console.warn(e);
+    d3.select('#title').text("Compare: " + summary.term);
+    d3.select('#date').text(summary.date);
+    var num_tweets = parseInt(summary.num_tweets);
+    d3.select('#num_tweets').text(num_tweets.toLocaleString());
+});
+
+
+</script>
+{% endblock javascript_extra %}
+
+{% block content %}
+<div class="row">
+    <h2 class="item">
+        Compare #<span id="search_id">{{ search.id }}</span>:
+        <span id="num_tweets"></span>
+        tweets collected on
+        <span id="date"></span>
+        <span id="date_path" style="display:none;">{{ search.date_path }}</span>
+    </h2>
+</div>
+{% endblock content %}


### PR DESCRIPTION
This code is a big mess but I've been staring at it for a while and wanted to get it over to you for at least a first review.  A clean UI would let users select two or more different searches and send them all through.  This doesn't - it only lets you pick two, from the bottom of the summary screen.  it orders the hashtags by the hashtag counts sorted on the first search (the one whose summary you were previous reviewing).  You can reverse the numbers in the URL pattern and add ids to the end to see more than two at once, e.g. `compare?ids=3,4,5` and the chart should give reasonable colors, spacing, etc. to all of them.

This somehow got me into the depths of where the API begins and ends and what I should do with pandas vs. just javascript.  Obviously I got a little bogged down in it.  It'll be easier to make some clean decisions about all this when we make framework choices and just build from there.  I hope.
